### PR TITLE
Avoid NullPointerException in PROVNReaderTest

### DIFF
--- a/src/main/java/br/uff/ic/utility/IO/InputReader.java
+++ b/src/main/java/br/uff/ic/utility/IO/InputReader.java
@@ -61,6 +61,9 @@ public abstract class InputReader {
     }
 
     public InputReader(File f){
+        if (! f.canRead()) {
+            throw new IllegalArgumentException("Invalid file: " + f);
+        }
         file = f;
         nodes = new HashMap<>();
         edges = new ArrayList<>();

--- a/src/test/java/br/uff/ic/utility/IO/PROVNReaderTest.java
+++ b/src/test/java/br/uff/ic/utility/IO/PROVNReaderTest.java
@@ -98,7 +98,8 @@ public class PROVNReaderTest {
     public void testRead() throws Exception {
 //        System.out.println("Read");
         String line = "wasGeneratedBy(e2, a1, -, [ex:fct=\\\"save\\\"])";
-        PROVNReader instance = new PROVNReader(null);
+        File f = File.createTempFile("empty", ".provn");
+        PROVNReader instance = new PROVNReader(f);
         instance.Read(line);
     }
 }


### PR DESCRIPTION
Avoid testRead() falling over because it passed `null` to `PROVNReader` constructor.

The file passed is actually empty as it tests the `.Read()` method directly.