### PR TITLE
Avoid wrong case for target/classes

### DIFF
--- a/src/main/java/br/uff/ic/utility/IO/BasePath.java
+++ b/src/main/java/br/uff/ic/utility/IO/BasePath.java
@@ -44,7 +44,7 @@ public class BasePath {
             String basePath = null;
             file = new File(clazz.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
             if (file.isFile() || file.getPath().endsWith(".jar") || file.getPath().endsWith(".zip")) {
-                basePath = file.getParent() + File.separator + "Classes";
+                basePath = file.getParent() + File.separator + "classes";
             } else {
                 basePath = file.getPath();
             }


### PR DESCRIPTION
.. as `Classes` won't work on case-sensitive file systems like in Linux.

Note that `Variables.demo` is still set to `workflow_trial_0.xml` which is not included in source code, so it still won't launch. Perhaps one of the .provn examples could be set instead?